### PR TITLE
lightrec: Fix lightrec_get_map host address calculation

### DIFF
--- a/lightrec.c
+++ b/lightrec.c
@@ -202,8 +202,9 @@ static const struct lightrec_mem_map *
 lightrec_get_map(struct lightrec_state *state,
 		 void **host, u32 kaddr)
 {
-	static const struct lightrec_mem_map *map;
+	const struct lightrec_mem_map *map;
 	unsigned int i;
+	u32 addr;
 
 	for (i = 0; i < state->nb_maps; i++) {
 		const struct lightrec_mem_map *mapi = &state->maps[i];
@@ -217,11 +218,13 @@ lightrec_get_map(struct lightrec_state *state,
 	if (i == state->nb_maps)
 		return NULL;
 
+	addr = kaddr - map->pc;
+
 	while (map->mirror_of)
 		map = map->mirror_of;
 
 	if (host)
-		*host = map->address + kaddr - map->pc;
+		*host = map->address + addr;
 
 	return map;
 }

--- a/lightrec.c
+++ b/lightrec.c
@@ -1399,6 +1399,10 @@ err_finish_jit:
 
 void lightrec_destroy(struct lightrec_state *state)
 {
+	/* Force a print info on destroy*/
+	state->current_cycle = ~state->current_cycle;
+	lightrec_print_info(state);
+
 	if (ENABLE_THREADED_COMPILER) {
 		lightrec_free_recompiler(state->rec);
 		lightrec_reaper_destroy(state->reaper);


### PR DESCRIPTION
When the mirror is not enabled need to subract the mirror's pc to get the actual location in RAM

I didn't quite get this logic right in b077980e, luckily I happened to test with mirrors disabled due to a leftover /dev/shm/lightrec_memfd from force killing a pcsx4all and then running beetle-psx, which doesn't yet have a way to deal with that.