### PR TITLE
Fix check for or/nor REG_EXT

### DIFF
--- a/emitter.c
+++ b/emitter.c
@@ -681,8 +681,8 @@ static void rec_special_or_nor(struct lightrec_cstate *state,
 
 	/* E(rd) = (E(rs) & E(rt)) | (E(rt) & !Z(rt)) | (E(rs) & !Z(rs)) */
 	if ((REG_EXT & flags_rs & flags_rt) ||
-	    (flags_rt & (REG_EXT | REG_ZEXT) == REG_EXT) ||
-	    (flags_rs & (REG_EXT | REG_ZEXT) == REG_EXT))
+	    ((flags_rt & (REG_EXT | REG_ZEXT)) == REG_EXT) ||
+	    ((flags_rs & (REG_EXT | REG_ZEXT)) == REG_EXT))
 		flags_rd |= REG_EXT;
 
 	lightrec_set_reg_out_flags(reg_cache, rd, flags_rd);


### PR DESCRIPTION
Otherwise the == has precedence over the &

Signed-off-by: Zachary Cook <zachcook1991@gmail.com>