### PR TITLE
Add optional cop2_notify callback to lightrec_ops

### DIFF
--- a/lightrec-private.h
+++ b/lightrec-private.h
@@ -123,6 +123,7 @@ struct lightrec_branch_target {
 enum c_wrappers {
 	C_WRAPPER_RW,
 	C_WRAPPER_RW_GENERIC,
+	C_WRAPPER_MFC,
 	C_WRAPPER_MTC,
 	C_WRAPPER_CP,
 	C_WRAPPERS_COUNT,

--- a/lightrec.c
+++ b/lightrec.c
@@ -457,6 +457,14 @@ u32 lightrec_mfc(struct lightrec_state *state, union code op)
 	return val;
 }
 
+static void lightrec_mfc_cb(struct lightrec_state *state, union code op)
+{
+	u32 rt = lightrec_mfc(state, op);
+
+	if (op.r.rt)
+		state->regs.gpr[op.r.rt] = rt;
+}
+
 static void lightrec_mtc0(struct lightrec_state *state, u8 reg, u32 data)
 {
 	u32 status, oldstatus, cause;
@@ -1784,6 +1792,7 @@ struct lightrec_state * lightrec_init(char *argv0,
 
 	state->c_wrappers[C_WRAPPER_RW] = lightrec_rw_cb;
 	state->c_wrappers[C_WRAPPER_RW_GENERIC] = lightrec_rw_generic_cb;
+	state->c_wrappers[C_WRAPPER_MFC] = lightrec_mfc_cb;
 	state->c_wrappers[C_WRAPPER_MTC] = lightrec_mtc_cb;
 	state->c_wrappers[C_WRAPPER_CP] = lightrec_cp_cb;
 

--- a/lightrec.h
+++ b/lightrec.h
@@ -85,6 +85,7 @@ struct lightrec_mem_map {
 };
 
 struct lightrec_ops {
+	void (*cop2_notify)(struct lightrec_state *state, u32 op, u32 data);
 	void (*cop2_op)(struct lightrec_state *state, u32 op);
 	void (*enable_ram)(struct lightrec_state *state, _Bool enable);
 	_Bool (*hw_direct)(u32 kaddr, _Bool is_write, u8 size);


### PR DESCRIPTION
The callback is given the full opcode and the data that was read or written to or from the cop2 register

The callback is expected to decode the opcode, for example to ignore LWC2/SWC2 and determine which of the MFC/CFC/MTC/CTC functions was called

This will be used to provide the opcode and return/data value to PGXP_GTE_[MFC/CFC/MTC/CTC] functions in beetle-psx that was lost when cop2 became internal to lightrec

Signed-off-by: Zachary Cook <zachcook1991@gmail.com>