### PR TITLE
Fix For Bug Found in 32bit X86 Build Target

### DIFF
--- a/emitter.c
+++ b/emitter.c
@@ -1872,7 +1872,11 @@ static void rec_load_direct(struct lightrec_cstate *cstate,
 		addr_reg = rt;
 		imm = 0;
 
-		if (c.i.rs != c.i.rt)
+		/* Use out_reg and not c.i.rt: for LWC2 opcodes or loads in
+		 * load delay slots the output register is REG_TEMP, and
+		 * c.i.rt is a COP2 register number that may alias the GPR
+		 * number in c.i.rs. */
+		if (c.i.rs != out_reg)
 			lightrec_free_reg(reg_cache, rs);
 	}
 

--- a/emitter.c
+++ b/emitter.c
@@ -2257,6 +2257,9 @@ rec_mtc0(struct lightrec_cstate *state, const struct block *block, u16 offset)
 
 
 		jit_patch(to_end);
+
+		lightrec_free_reg(reg_cache, tmp);
+		lightrec_free_reg(reg_cache, tmp2);
 	}
 
 	if (!op_flag_no_ds(block->opcode_list[offset].flags) &&


### PR DESCRIPTION
To be clear this was heavily guided with AI assisted debugging, i only have a 64bit and 32bit WIN based machine so my testing is limited to those devices. Understood if you rather be AI free and or would need to test on more devices. Figured it would be worth sharing as it fixed a large FPS drop in Ape Escape on my 32 bit build target. Cheers!

Commit 1 
emitter: Fix leaked register in rec_load_direct for LWC2 opcodes
In the imm != 0 path, the early free of the base address register is
guarded by "c.i.rs != c.i.rt". For LWC2 opcodes (and loads in load
delay slots) the output register is REG_TEMP, and c.i.rt is a COP2
register number; when that number happens to match the GPR number in
c.i.rs (e.g. "lwc2 $5, 4($5)"), the guard wrongly skips the free,
leaving the base register marked as used for the remainder of the
block being compiled.

On 32-bit x86 only four native registers are allocatable, so leaked
registers quickly exhaust the register allocator; the allocators
return 0 on failure (a valid, live register number that callers never
check), and the emitter then silently generates corrupt code. Exposed
by Ape Escape (SCUS-94423), whose GTE code hits the aliasing pattern
constantly: one corrupted block dropped gameplay from 30fps to 8fps.

Compare against out_reg instead, which is the register that is
actually written.

Commit 2

emitter: Fix leaked temporaries in rec_mtc0
rec_mtc0 allocates tmp and tmp2 for the Status/Cause interrupt checks
but never frees them, leaving both marked as used for the remainder of
the block being compiled.

On 32-bit x86 only four native registers are allocatable, so a single
inlined MTC0 to the Status or Cause register makes half of the pool
unavailable, contributing to register allocator exhaustion — which
silently generates corrupt code, as the allocators' failure value 0 is
a valid register number that callers never check. Exposed by Ape
Escape (SCUS-94423) in combination with an LWC2 register leak.